### PR TITLE
Add an exclude for a site with no anti-adblock.

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -30,6 +30,7 @@
 // @exclude http*://*.ask.com/*
 // @exclude http*://*.live.com/*
 // @exclude http*://*.msn.com/*
+// @exclude http*://*.nyaa.se/*
 // @exclude http*://*.tumblr.com/*
 // @exclude http*://*.microsoft.com/*
 // @exclude http*://*.paypal.com/*


### PR DESCRIPTION
This script breaks nyaa.se if it runs, by preventing a script called run.js from executing.
This script unhides page content which has already loaded, so it likely triggers the anti-adblock filter.

Adding a user exclude for this site makes it work again.
The site doesn't interfere with adblock as it is.
