### PR TITLE
linkcrypt_ws

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -2014,9 +2014,9 @@ Aak = {
       linkcrypt_ws : {
       	host : ['linkcrypt.ws'],
       	onLoad : function () {
-       		document.getElementById('ad_cont').style.display='';
-        	document.getElementById('ad_cont').id = '';
-		document.getElementById('container_check').style.display='none'; 
+          document.getElementById('ad_cont').style.display='';
+          document.getElementById('ad_cont').id = '';
+          document.getElementById('container_check').style.display='none'; 
       	}
       }
     },


### PR DESCRIPTION
Naive method to prevent linkcrypt.ws to hide the container buttons with adblock.
