### PR TITLE
Fixed reek's "* Kill: gram.pl"

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1093,7 +1093,7 @@ hireteen.com###adb-enabled
 ! binbox.io
 @@||binbox.io/adblock.js$script
 ! gram.pl
-gram.pl###ab
+@@|http://static0.gram.pl/js/advertising.js$script,domain=gram.pl
 !----------------------------------------------------------------------------------------------------!
 ! FuckAdBlock (Specific)
 !----------------------------------------------------------------------------------------------------!


### PR DESCRIPTION
Because adding "gram.pl###ab" to the filters list doesn't fix the problem.