### PR TITLE
Fix blank space & remove 4chan nagging

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1110,10 +1110,7 @@ comptoir-info.com#@#.textad
 @@||pagead2.googlesyndication.com/pagead/show_ads.js$script,domain=adultmult.tv
 @@||pagead2.googlesyndication.com/pagead/js/r*/r*/show_ads_impl.js$script,domain=adultmult.tv
 ! 4chan.org
-4chan.org#@#.ad-plea
-4chan.org#@#.topad
-4chan.org#@#.middlead
-4chan.org#@#.bottomad
+4chan.org##.center[style]
 ! mega-faucet.eu
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=mega-faucet.eu
 @@||pagead2.googlesyndication.com/pagead/js/r*/r*/show_ads_impl.js$script,domain=mega-faucet.eu


### PR DESCRIPTION
In commit https://github.com/reek/anti-adblock-killer/commit/6f2deef4f31fca614cd8be835eb82d69d71a1d0c, the following lines were added for 4chan.org:
```
! 4chan.org
4chan.org#@#.ad-plea
4chan.org#@#.topad
4chan.org#@#.middlead
4chan.org#@#.bottomad
```
Instead of whitelisting the ad spots, which leaves blank space
![ahe60sazrcvq 1](https://cloud.githubusercontent.com/assets/4343306/9028910/29294f18-394e-11e5-88c1-67bbce0f327d.png)
the nagging
![r2zjy9q1lur3 1](https://cloud.githubusercontent.com/assets/4343306/9028942/4fca1480-394f-11e5-9c19-d140dc34c547.png)
can be hidden by adding 4chan.org##.center[style]
![zgeezbvnfcq0 1](https://cloud.githubusercontent.com/assets/4343306/9028914/5552d51e-394e-11e5-84ab-ea9b716101d8.png)