### PR TITLE
Fixes issue #540 (broken Firefox's "Get Add-Ons" page)

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -127,7 +127,7 @@
 /adblock_detector.
 /adblockdetect.
 /adblockdetection.
-/anti-adblock$~stylesheet
+/anti-adblock$~stylesheet,~domain=mozilla.org
 /anti_ab.
 /antiadblock.
 /wp-content/plugins/anti_ad_blocker/*


### PR DESCRIPTION
Excludes the *mozilla.org* domain from the `/anti-adblock$~stylesheet` filter. I didn't want to be too specific (e.g. *services.addon.mozilla.org*) as I doubt Mozilla is starting to use anti-adblock on its public pages soon :P
#540