### PR TITLE
Fix for Exashare support / Dowed.info

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -371,6 +371,13 @@ exashare.com##[href="http://www.videohube.eu/script/url.php?c=ep"]
 @@||exashare.com/ads.js$script
 @@||pubdirecte.com/script/$script,$domain=exashare.com
 @@||pubdirecte.com/image/$image,domain=exashare.com
+! dowed.info
+dowed.info###player_img
+dowed.info###player_imgo
+dowed.info##[href="http://www.videohube.eu/script/url.php?c=ep"]
+@@||dowed.info/ads.js$script
+@@||pubdirecte.com/script/$script,$domain=dowed.info
+@@||pubdirecte.com/image/$image,domain=dowed.info
 ! mydisc.net
 mydisc.net#@#.ad_1
 mydisc.net#@#.ad_2

--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -2503,14 +2503,15 @@ Aak = {
     exashare_com : {
       // by: Watilin
       // issue: https://github.com/reek/anti-adblock-killer/issues/624
+      // test: http://exashare.com/galw2ge2kzsv
       host : ['exashare.com', 'dowed.info'],
       onEnd : function () {
         var jwplayer = Aak.uw.jwplayer;
-        if (jwplayer) {
-          var setupScript = Aak.getScript("setup");
-
-          var match = setupScript.innerHTML.match(
-              /\bjwplayer\s*\(\s*(["'])(.+?)\1\s*\)\s*\.\s*setup\s*\(\s*(\{(?:.|\s)+?\})\s*\)\s*;/);
+        
+        var injectFix = function (setupText, player) { // drugs are bad
+          var match = setupText.match(
+            /\bjwplayer\s*\(\s*(["'])(.+?)\1\s*\)\s*\.\s*setup\s*\(\s*(\{(?:.|\s)+?\})\s*\)\s*;/
+          );
 
           var id = match[2];
           var setupStr = match[3];
@@ -2539,9 +2540,33 @@ Aak = {
           }
             .toString()
             .replace("_setupStr_", setupStr)
-            .replace("_id_", id));
+            .replace("_id_", id)
+          );
 
           Aak.addScript("(" + contentFunction + "());");
+        };
+
+        if (jwplayer) { // embedded player
+
+          var setupScript = Aak.getScript("setup");
+          injectFix(setupScript.innerHTML, jwplayer);
+
+        } else {
+
+          /* On the in-site player page, scripts are still present in
+          the HTML but have been commented out. We're looking for them
+          to retrieve the setup part, except this time jwplayer hasn't
+          been initialized, so we use our own. */
+
+          var htmlComments = document.body.innerHTML.match(/<!--(.|\n)*?-->/g);
+          var setupComment = htmlComments ?
+            htmlComments.filter(function (s) {
+              return Aak.contains(s, "setup");
+            })[0] :
+            null;
+
+          if (setupComment) injectFix(setupComment, Aak.jwplayer6);
+
         }
       }
     },

--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -2502,10 +2502,8 @@ Aak = {
     },	
     exashare_com : {
       // by: Watilin
-      // pull: https://github.com/reek/anti-adblock-killer/pull/519
-      // issue: https://github.com/reek/anti-adblock-killer/issues/486
-      // issue: https://github.com/reek/anti-adblock-killer/issues/506
-      host : ['exashare.com'],
+      // issue: https://github.com/reek/anti-adblock-killer/issues/624
+      host : ['exashare.com', 'dowed.info'],
       onEnd : function () {
         var jwplayer = Aak.uw.jwplayer;
         if (jwplayer) {


### PR DESCRIPTION
Exashare guys have moved their player to a new domain dowed.info, and commented out some scripts on their in-site player. This PR fixes Aak to match those changes.

As the branch name states, it addresses issue #624.