### PR TITLE
add geo.de

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1439,6 +1439,9 @@ shinden.pl#@#.AD-RC-300x250
 @@||bild.de^$elemhide
 @@||sascdn.com^$domain=bild.de
 @@||smartadserver.com^$domain=bild.de
+! geo.de
+geo.de##div.lp_mwi_dialog-overlay.lp_mwi_dialog-overlay--is-active
+geo.de##.lp_mwi_dialog-wrapper
 ! itespresso.fr
 ! https://github.com/reek/anti-adblock-killer/issues/686
 @@/advertising.js$script,domain=itespresso.fr


### PR DESCRIPTION
No Anti Adblock on main page but on sub-pages (Articles).
Example: http://www.geo.de/GEO/reisen/reiseziele/frankreich-herbstreiseziel-saint-malo-81681.html