### PR TITLE
XenForo Rellect AdBlock Detector Fix v1

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -1663,6 +1663,19 @@ Aak = {
         Aak.addBaitElement('ins.adsbygoogle');
       }
     },
+    rellect_adsbygoogle_annihilate : {
+        host : ['scriptznull.nl', 'broadbandforum.co'],
+        onBeforeScript : function (e) {
+            if ((/XenForo\.rellect\.AdBlockDetectorParams\.loadScript/ig.test(Aak.innerScript(e))) == 1) {
+                Aak.stopScript(e);
+                Aak.createElement({
+                    tag : 'script',
+                    text : e.target[('innerText' in document) ? 'innerText' : 'textContent'].replace(/XenForo\.rellect\.AdBlockDetectorParams\.loadScript\s*?\([\s\S]+?\)\s*?;/ig, '').trim(),
+                    replace : e.target
+                });
+            }
+        }
+    },
     bait_tester : {
       host : ['osoarcade.com', 'd3brid4y0u.info', 'fileice.net', 'nosteam.ro', 'openrunner.com', 'easybillets.com', 'spox.fr', 'yovoyages.com', 'tv3.co.nz', 'freeallmusic.info', 'putlocker.com', 'sockshare.com', 'dramapassion.com', 'yooclick.com', 'online.ua'],
       onStart : function () {


### PR DESCRIPTION
**References / Related threads:**
https://github.com/reek/anti-adblock-killer/issues/804
https://github.com/reek/anti-adblock-killer/issues/805

@MajkiIT @reek Thanks. But the solutions proposed by you, do not work for me.

`googlesyndication.com/pagead/js/adsbygoogle.js` is already blocked by uBO/Ghostery. `.adsbygoogle` is already defined in EasyList. So I guess there's no point in adding those as static filters again!

Take a look at the source:

```javascript
XenForo.rellect.AdBlockDetectorParams.loadScript(
	'js/rellect/AdblockDetector/handler.min.js?rev=XX',
	false,
	AdBlockDetectorWorkaround
);
```
So **IF** `js/rellect/AdblockDetector/handler.min.js` file is blocked, the script executes the associated fallback function: `AdBlockDetectorWorkaround` :

```javascript
var AdBlockDetectorWorkaround = function(){
	/* This is just in case the handler script is blocked by the adblocker */
	if(!XenForo.rellect.AdBlockDetector){
		console.log('AdBlock detector failed. Trying workaround.');
		XenForo.ajax('index.php', {dataType: 'html', AdblockDetector: 1}, function(ajaxData){
			if(XenForo.hasTemplateHtml(ajaxData)){
				try{
					jQuery.globalEval(ajaxData.templateHtml);
				}
				catch(e){}
			}
		}, {
			error: function(){
				console.log('AdBlock detector workaround failed.');
			}
		});
	}
};
```
The above script directly issues the "Adblocker Detected" pop-up.

Now take a look at the minified JS at: `broadbandforum.co/js/rellect/AdblockDetector/handler.min.js`. There are various versions of `handler.min.js` by the author. A different one is used on: `scriptznull.nl/js/rellect/AdblockDetector/handler.min.js`

The latest one used on: `broadbandforum.co` searches for any element defined by the CSS selector: `ins.adsbygoogle`, checks whether it is visible or hidden, checks whether the global variable: `window.adsbygoogle` is defined & also the `push` property on `window.adsbygoogle` is defined or not.

If no element is returned or the element is in hidden state or the above conditions are not met, it tries to load `googlesyndication.com/pagead/js/adsbygoogle.js` (which is already blocked by uBO/Ghostery).

As soon as it fails to load the `adsbygoogle.js`, it issues the "Adblocker Detected" pop-up.

**I found 2 ways to approach this:**

**[1]** Create a dummy visible element: `ins.adsbygoogle` and an empty `window.adsbygoogle` object with a dummy `push` property so that all the scripts are happy... but since there are different versions of Rellect's `handler.min.js` floating around, supporting all conditions on each iteration of the script would be PITA.

**[2]** Cull the script at its inception,... before it gets executed by removing the relevant script block from the DOM, modifying its contents, then re-adding the modified script block. We just need to remove the following js before it gets executed, then re-add the concerned script block it's a part of and that's all!

```javascript
XenForo.rellect.AdBlockDetectorParams.loadScript(
	'js/rellect/AdblockDetector/handler.min.js?rev=XX',
	false,
	AdBlockDetectorWorkaround
);
```
---
So here's the fix (add the following to the 'rules' section of @reek 's script OR use the 'edited script' from below):
```javascript
rellect_adsbygoogle_annihilate : {
    host : ['scriptznull.nl', 'broadbandforum.co'],
    onBeforeScript : function (e) {
        if ((/XenForo\.rellect\.AdBlockDetectorParams\.loadScript/ig.test(Aak.innerScript(e))) == 1) {
            Aak.stopScript(e);
            Aak.createElement({
                tag : 'script',
                text : e.target[('innerText' in document) ? 'innerText' : 'textContent'].replace(/XenForo\.rellect\.AdBlockDetectorParams\.loadScript\s*?\([\s\S]+?\)\s*?;/ig, '').trim(),
                replace : e.target
            });
        }
    }
}
```
***
**Pull Request:**
https://github.com/reek/anti-adblock-killer/pull/812
***
**Commit Changes/Difference:**
https://github.com/skr4tchGr3azyMonkiBallllllZzzz/anti-adblock-killer/commit/467775e816014a69603299b5cda0ff6d1da640bb
***
**Edited script you can use right now (to block the pop-up):**
https://raw.githubusercontent.com/skr4tchGr3azyMonkiBallllllZzzz/anti-adblock-killer/467775e816014a69603299b5cda0ff6d1da640bb/anti-adblock-killer.user.js