### PR TITLE
* Fix: animeheaven.eu

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1617,7 +1617,7 @@ hentenaar.com#@#.adsbygoogle
 @@||6play.fr/media/js/publicite.js
 ! animeheaven.eu
 ! https://github.com/reek/anti-adblock-killer/issues/789
-@@||animeheaven.eu/a/showads$script
+@@||animeheaven.eu/*/showads$script
 ! skyrock.com
 skyrock.com##IMG[src*="adblock/pave.png"]
 skyrock.com##IMG[src*="adblock/megabanner.png"]


### PR DESCRIPTION
Example URL: http://animeheaven.eu/watch.php?a=Is%20the%20Order%20a%20Rabbit&epi=1
Block: http://i.imgur.com/6YB49Xt.png
Browser: Chrome
Userscript manager: Tampermonkey
Adblocker: uBlock
Lists: EasyList + AakList

In current version: "@@||animeheaven.eu/a/showads$script"
Fixed: "@@||animeheaven.eu/*/showads$script"
Blocked resource: http://i.imgur.com/vOawzTW.png
The /a/ has been changed to /b/, in the fix I changed it to * for future proofing.