### PR TITLE
fix habrahabr.ru geektimes.ru megamozg.ru

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1349,6 +1349,7 @@ fossbytes.com#@##adsense
 ! geektimes.ru
 ! https://github.com/reek/anti-adblock-killer/issues/606
 @@/advertising.js$script,domain=habrahabr.ru|megamozg.ru|geektimes.ru
+@@/adriver.js$script,domain=habrahabr.ru|megamozg.ru|geektimes.ru
 ! sharefreeall.com
 ! https://github.com/reek/anti-adblock-killer/issues/623
 sharefreeall.com#@##adsense


### PR DESCRIPTION
Fix habrahabr.ru geektimes.ru megamozg.ru anti-adblock.

Their new bait script is //habracdn.net/habr/javascripts/[0-9]+/adriver.js

and code checks for adriver object presence.
