### PR TITLE
debridnet.com - make anti adblock working again

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -1769,9 +1769,9 @@ rlsbb.movie7share.net##.information > [color="red"] > H3
 ! debridnet.com
 ! https://github.com/reek/anti-adblock-killer/issues/1077
 ! https://github.com/reek/anti-adblock-killer/issues/836
-||debridnet.com/blocker.js$script
-||debridnet.com/b1.js$script
-||debridnet.com/b2.js$script
+@@||debridnet.com/b1.js$script
+!@@||debridnet.com/b2.js$script
+@@||tags.h12-media.com/load.js$script,domain=debridnet.com
 ! wwwshooter.com
 ! https://github.com/reek/anti-adblock-killer/issues/835
 @@||wwwshooter.com/js/adblockdetect/_advertisement.js$script


### PR DESCRIPTION
Well blocking http://debridnet.com/b1.js will avoid the debridnet.com/ad-blocker screen poping up.
BUT as well damage the function of the Generate Button.
That's code of http://debridnet.com/b1.js :
f	function myFunction3() {
		if ($('.myTestAd2').height() == 0) {
			document.getElementById('form').action = '';
			document.getElementById('gr').value = '';
			document.getElementById('gr').disabled = true;
			document.getElementById('gr').id = '';
			window.location.replace("http://debridnet.com/ad-blocker");
		} else {
			document.getElementById('form').action = 'generate';
			document.getElementById('gr').disabled = false;
		}
	}

It'll enable the 'Generate' button.
...('form').action = 'generate'
...('gr').disabled = false;
If it's missing the button stays disable and even when you enable it(manually) still the action 'generate' is missing(you may add this manually as well to make it working).

tags.h12-media.com/load.js is somehow need to create '.myTestAd2' to the 'GOOD' else branch of the if will get triggered