### PR TITLE
Disable comment hiding on topsport.bg

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -3151,3 +3151,5 @@ gaara-fr.com###pub01
 gaara-fr.com###ga-skin-left
 gaara-fr.com###ga-skin-right
 gaara-fr.com###ga-skin-top
+! topsport.bg
+@@||partner.googleadservices.com/gpt/$script,domain=topsport.bg


### PR DESCRIPTION
Website uses javascript request to fetch data from partner.googleadservices.com, and if it fails it blocks reading and writing of comments below the articles. Google DFP configuration is stored in a separate file (dfp.js), which is blocked by most filter, so no ads are served despite adding this rule.