### PR TITLE
Fix 3dsthem.es

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -1965,7 +1965,7 @@ Aak = {
       },
       onIdle : function () {
         Aak.setElement('#pw_adbox_77830_5_0', {
-          html : '<br>'
+          html : '<br><br>'
         });
       }
     },


### PR DESCRIPTION
http://i.imgur.com/4gfTml4.png
It seems they've patched Aak Script again. 

> if(
> 				(el.html() === "" ||
> 				el.css('visibility') === "hidden" ||
> 				el.css('display') !== "inline-block" ||
> 				el.height() === 0 ||
> 				el.html() === "&lt;br&gt;" ||
> 				el.css('width') === '1px') &&
> 				!$("#adblockpls").length
> 			)

I don't know programming languages so I'm not 100% sure, but it looks like if "html = &lt;br&gt;" is true, then the adblocker detected message shows up.
I figured you can avoid this by changing the 1968th line of the script 
> html : '&lt;br&gt;'

to something like this

> html : '&lt;br&gt;&lt;br&gt;'