### PR TITLE
Block tryMask.com (anti-Adblock service)

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -3439,6 +3439,3 @@ gaara-fr.com###pub01
 gaara-fr.com###ga-skin-left
 gaara-fr.com###ga-skin-right
 gaara-fr.com###ga-skin-top
-
-
-


### PR DESCRIPTION
These URLs are confirmed for Iframes. tested on http://www.getgrubbing.com/ (trymask.com demo site) (Chrome, Windows, Ublock Origin)

https://trymask.com/api/v1/script/widget
https://trymask.com/api/v1/script/popup
https://trymask.com/api/v1/script/banner

Visual Filter is here because otherwise there will be a [X] close button on the page.