### PR TITLE
anti ads block

### DIFF
--- a/antiads block
+++ b/antiads block
@@ -1,0 +1,5 @@
+@@||brassyobedientcotangent.com^$script
+@@||dailycaller.com^$generichide
+dailycaller.com##DIV[class="small-12 columns blank"]
+dailycaller.com##.OUTBRAIN
+||outbrain.com^$domain=dailycaller.com


### PR DESCRIPTION
this is for blocking anti adblock ads on the daily caller
https://imgur.com/a/ZMQKu
this is on firefox 
there is no anti adblock wall it just blocks the ads on adreclaim
Adblock Plus+ Adblock
EasyList + AakList