### PR TITLE
Another Last.FM Anti-Ad Script

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -3037,6 +3037,7 @@ lfg.co,leasticoulddo.com#@#.act-ad-container
 @@||$xmlhttprequest,domain=last.fm
 @@||adsensecustomsearchads.com/adsense/$script,domain=last.fm
 @@||securepubads.g.doubleclick.net$script,domain=last.fm
+@@||dw.cbsimg.net$script,domain=last.fm
 ! liliputing.com
 ! https://github.com/reek/anti-adblock-killer/issues?q=liliputing.com
 @@||liliputing.com^$generichide


### PR DESCRIPTION
Added dw.cbsimg.net as blocking that script causes anti-adblocker script to fire. 

http://dw.cbsimg.net/js/cbsi/ds.js is the exact script.