### PR TITLE
Add support for disabling Admiral

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -17,6 +17,10 @@
 !
 ! ----- Generic ----- !
 !
+! Admiral
+! https://getadmiral.com
+! Triggers shortly after the page finishes loading and the user begins interacting with the page (mouse movement)
+unknowntray.com/*
 ! TryMask.com
 ! https://trymask.com/ (home)
 ! http://www.getgrubbing.com/ (demo)


### PR DESCRIPTION
This PR adds support for Admiral, another anti-adblock script.

This one's odd in that the site hosting it completely stopped sending the bootstrapper script to my browser after a little while.

When it did trigger, it did so shortly after the page finished loading. It removed the real page content and replaced it with a box asking me to whitelist the site.

The script itself comes from "unknowntray.com", and blocking this was enough to stop it from working.

The site I saw this on was venturebeat.com.

This is the bootstrapper on the page that loads the full Admiral script:
```javascript
(function(a, b, c, d, e) {
    e = a.createElement(b);
    a = a.getElementsByTagName(b)[0];
    e.async = 1;
    e.src = c;
    a.parentNode.insertBefore(e, a)
})(document, 'script', '//unknowntray.com/4430b41e83ded20e5f99d3149b838ba9394d5a075c316121705ccd1543bc9320fc690f12c8d6e27a206b5ebdc92207d119db270253373b3e5d39c687bcb5');
```

The script at unknowntray.com/... can be found here in case anyone wants to figure out what it does:
https://archive.fo/NvQVV