### PR TITLE
Adds rule for thefreedictionary.com

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -3805,7 +3805,7 @@
         // issue: https://github.com/reek/anti-adblock-killer/issues/178
         // issue: https://github.com/reek/anti-adblock-killer/issues/196
         // issue: https://github.com/reek/anti-adblock-killer/issues/56
-        host : ['kissanime.com', 'kissanime.to'],
+        host : ['kissanime.com', 'kissanime.to', 'kissanime.me', 'kissanime.ru'],
         onStart : function () {
           // Masking ads
           Aak.addStyle('iframe[id^="adsIfrme"], .divCloseBut { display:none; }');

--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -1563,6 +1563,26 @@
           }
         }
       },
+      thefreedictionary_com : {
+        // Site: www.thefreedictionary.com
+        // shows back the site's word meaning when it tries to remove it.
+        host : ['thefreedictionary.com', 'tfd.com'],
+        onIdle : function () {
+          var contentDiv = document.getElementById('content'),
+              bodyDiv = document.getElementById('w1');
+
+          // Tamper the 'warn()' function not to create the top 'terror' banner
+          if (warn) {
+            warn = function() {
+              console.log("Tampermonkey/anti-adblock-killer(avengerx): Suppressed thefreedictionary snag banner!");
+            };
+          }
+
+          if (contentDiv && contentDiv.classList.length > 0) {
+            contentDiv.classList = {};
+          }
+        }
+      },
       openuserjs_org : {
         host : ['openuserjs.org'],
         onIdle : function () {


### PR DESCRIPTION
Will allow the content to be displayed and also suppress the annoying top banner alerting about the ad-blocker.

**Note:** I understand this project is dead. I'm just leaving the pull request so people can benefit from the fix I found (if anybody else been annoyed with thefreedictionary as I was! hehe). Works for me on Chrome.

The extra linebreak in the end of the file is github's fault. I edited the file directly on github, pasting the code I added on my file locally.