### PR TITLE
Kill: haaretz.com

### DIFF
--- a/anti-adblock-killer.user.js
+++ b/anti-adblock-killer.user.js
@@ -2797,7 +2797,7 @@
       themarker_haaretz : {
         // issue: https://github.com/reek/anti-adblock-killer/issues/1292
         // source: http://pastebin.com/m08dkDT4
-        host : ['themarker.com', 'haaretz.co.il'],
+        host : ['themarker.com', 'haaretz.co.il', 'haaretz.com'],
         onStart : function () {
           Object.defineProperty(Aak.uw, 'AdBlockUtil', {
             enumerable : true,


### PR DESCRIPTION
Same logic used on themarker.com and haaretz.co.il also recently rolled out to the haaretz.com domain. This kills it.