### PR TITLE
Update anti-adblock-killer-filters.txt

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -3848,6 +3848,8 @@ urlchecker.net###ads_notify
 urlchecker.org###adchecker
 urlchecker.org###adchecker_btn
 urlchecker.org###ads_notify
+!spiegel.de
+||spiegel-de.spiegel.de
 !
 ! ----- Internal Use ------------------------------------------------------------------------------------------------------------------- !
 !


### PR DESCRIPTION
add filter to remove anti-adblocker pop-up on spiegel.de