### PR TITLE
Remove broken filter

### DIFF
--- a/anti-adblock-killer-filters.txt
+++ b/anti-adblock-killer-filters.txt
@@ -2988,8 +2988,6 @@ reuters.com##.RTVSyndicatedPlayer
 ! flashx.tv
 ! https://github.com/reek/anti-adblock-killer/issues?q=flashx.tv
 @@||flashx.tv/js/-fleshlight2.js$script
-! record.xl.pt
-@@||aminhaconta.xl.pt/Campaigns/Blockers/ads.html$subdocument,document=record.xl.pt
 ! ojogo.pt
 @@||ojogo.pt/common/scripts/ads.js$script
 ojogo.pt###AdBloquer


### PR DESCRIPTION
Remove invalid filter which is breaking the list from working with ublock origin.

![SCR-20230427-mzgd](https://user-images.githubusercontent.com/862951/234760797-12a09b48-016c-4809-bc8c-e5631d2d2a26.png)
![SCR-20230427-mynl](https://user-images.githubusercontent.com/862951/234760805-bb549a20-177d-49c4-a8eb-b26e3b3fc928.png)
